### PR TITLE
Tk penceresinin kaldırılması, yeni özellikler ve hata ayıklama

### DIFF
--- a/label_checker_v5.4.1.py
+++ b/label_checker_v5.4.1.py
@@ -20,11 +20,21 @@ messagebox.showwarning(
     'UYARI!!', 'Boşluk tuşu ile bir sonraki resme geçebilirsiniz. Onaylamak için "a" tuşuna, reddetmek için "r" tuşuna, geri almak için "u" tuşuna ve çıkmak için ise "q" veya da "esc" tuşuna basınız'
 )
 
-messagebox.showinfo("Resim", "Resim yolunu seçiniz.")
-image_folder_path = filedialog.askdirectory()
-messagebox.showinfo("Etiket", "Etiket yolunu seçiniz.")
-label_folder_path = filedialog.askdirectory()
+image_folder_path = filedialog.askdirectory(
+    mustexist=True,
+    title='Resimlerin bulunduğu klasör'
+)
 
+if image_folder_path == '':
+    exit(0)
+
+label_folder_path = filedialog.askdirectory(
+    mustexist=True,
+    title='Etiketlerin bulunduğu klasör'
+)
+
+if label_folder_path == '':
+    exit(0)
 
 image_files = [
     f for f in os.listdir(image_folder_path)

--- a/label_checker_v5.4.1.py
+++ b/label_checker_v5.4.1.py
@@ -131,8 +131,10 @@ def update_display(event):
     if os.stat(label_path).st_size == 0:
         print(f"Etiket dosyası boş: {label_path}")
     else:
-        print(f"{image_name}:{label_name}\n Etiket: \n{label_file_contents}")
-        root.title(f'Label Checker----{image_name} ----- {label_name} ----')
+        print(f'{image_name}:{label_name}\nEtiket:\n{label_file_contents}\n----')
+        root.title(
+            f'Label Checker - {display_data["formatted_file_number"]} - {image_name} | {label_name}'
+        )
 
     if os.sep == '\\':
         image_path = image_path.replace('/', os.sep)
@@ -271,7 +273,8 @@ def label_thread_main(tkObj: tkinter.Tk, key_event: threading.Event, key_var: tk
         display_data = {
             'image_path': image_path,
             'label_path': label_path,
-            'coordinates': coordinates
+            'coordinates': coordinates,
+            'formatted_file_number': f'{file_number}/{len(zipped_list)}'
         }
 
         tkObj.event_generate('<<update_display>>')

--- a/label_checker_v5.4.1.py
+++ b/label_checker_v5.4.1.py
@@ -156,8 +156,6 @@ def update_display(event):
         print(f"Error loading image: {e}")
         return
 
-    canvas.delete('all')
-
     canvas.create_image((0, 0), image=canvas_current_image, anchor='nw')
 
     vehicle_count = 0
@@ -228,10 +226,6 @@ canvas.pack()
 
 
 def move_files(image_old_path, image_new_path, label_old_path, label_new_path):
-    print(
-        f"Resim ve etiket dosyaları taşınıyor: {image_old_path}, {label_old_path} --> {image_new_path}, {label_new_path}"
-    )
-
     shutil.move(
         image_old_path,
         image_new_path

--- a/label_checker_v5.4.1.py
+++ b/label_checker_v5.4.1.py
@@ -122,14 +122,17 @@ undoable_actions = []
 def update_display(event):
     image_path: str = display_data['image_path']
     label_path: str = display_data['label_path']
+
     coordinates: list = display_data['coordinates']
+
     image_name = os.path.basename(image_path)
     label_name = os.path.basename(label_path)
-    print(os.path.basename(image_path))
+
     with open(label_path, 'r') as file:
         label_file_contents = file.read()
+
     if os.stat(label_path).st_size == 0:
-        print(f"Etiket dosyası boş: {label_path}")
+        print('Etiket dosyası boş')
     else:
         print(f'{image_name}:{label_name}\nEtiket:\n{label_file_contents}\n----')
         root.title(
@@ -201,9 +204,6 @@ def update_display(event):
                     outline=label_color,
                     width=2
                 )
-    print(
-        f"Taşıt sayısı: {vehicle_count}, İnsan sayısı: {person_count}, UAP sayısı: {uap_count}, UAI sayısı: {uai_count}"
-    )
     text_label.config(
         text=f"Taşıt sayısı: {vehicle_count}, İnsan sayısı: {person_count}, UAP sayısı: {uap_count}, UAI sayısı: {uai_count}"
     )

--- a/label_checker_v5.4.1.py
+++ b/label_checker_v5.4.1.py
@@ -143,6 +143,8 @@ def update_display(event):
         image_path = image_path.replace('\\', os.sep)
         label_path = label_path.replace('\\', os.sep)
 
+    canvas.delete('all')
+
     global canvas_current_image
     try:
         canvas_current_image = ImageTk.PhotoImage(

--- a/label_checker_v5.5.1.py
+++ b/label_checker_v5.5.1.py
@@ -13,7 +13,7 @@ from PIL import ImageTk, Image
 from datetime import datetime
 
 """
-usage='Boşluk tuşu ile bir sonraki resme geçebilirsiniz. Onaylamak için "a" tuşuna, reddetmek için "r" tuşuna, geri almak için "u" tuşuna ve çıkmak için ise "q" veya da "esc" tuşuna basınız.'
+usage='Bir sonraki resme geçmek için "->" tuşuna, onaylamak için "a" tuşuna, reddetmek için "r" tuşuna, işlemi geri almak için "<-" tuşuna ve çıkmak için ise "q" veya da "esc" tuşuna basınız.'
 """
 
 label_color_mapping: dict = {
@@ -37,7 +37,7 @@ root: tkinter.Tk = tkinter.Tk(className='Label Checker Root')
 root.withdraw()
 
 messagebox.showwarning(
-    'UYARI!!', 'Boşluk tuşu ile bir sonraki resme geçebilirsiniz. Onaylamak için "a" tuşuna, reddetmek için "r" tuşuna, geri almak için "u" tuşuna ve çıkmak için ise "q" veya da "esc" tuşuna basınız'
+    'UYARI!!', 'Bir sonraki resme geçmek için "->" tuşuna, onaylamak için "a" tuşuna, reddetmek için "r" tuşuna, işlemi geri almak için "<-" tuşuna ve çıkmak için ise "q" veya da "esc" tuşuna basınız.'
 )
 
 image_folder_path = filedialog.askdirectory(

--- a/label_checker_v5.5.1.py
+++ b/label_checker_v5.5.1.py
@@ -233,7 +233,9 @@ def update_display(event) -> None:
 
 def key_press(e) -> None:
     global pressed_key_obj, key_event
-    pressed_key_obj['char'] = chr(e.keycode).lower()
+    pressed_key_obj['char'] = e.char.lower()
+    pressed_key_obj['keycode'] = e.keycode
+    pressed_key_obj['keysym'] = e.keysym
     key_event.set()
 
 
@@ -390,8 +392,14 @@ def label_thread_main(tkObj: tkinter.Tk, key_event: threading.Event, key_obj: di
                 file_number -= 1
 
                 break
-            elif key_obj.get('char') == ' ':
+            elif key_obj.get('keysym') == 'Right':
                 file_number += 1
+                break
+            elif key_obj.get('keysym') == 'Left':
+                if file_number > 1 and list_index >= 1:
+                    file_number -= 1
+                    list_index -= 1
+                list_index -= 1
                 break
             else:
                 continue


### PR DESCRIPTION
**Yapılanlar:**
• Tk penceresi kaldırıldı.
• • Oluşma sebebi mesaj kutularının root pencereden önce kullanılmasıymış. Bu işlevler tkinter'in __init__.py dosyasını çalıştırıyor ve kendi root penceresini oluşturuyormuş.
• Resim ve etiketlerin seçileceğini gösteren mesaj kutuları kaldırılıp diyalogların başlıkları değiştirildi.
• Pencere başlığına kontrol edilen ve tüm veri sayısını gösteren göstergeç eklendi.
• update_display fonksiyonunda resim ve etiket dosyasının bulunamaması durumunda hata fırlatılması durumu dosyaların olup olmamasının kontrol edilmesiyle çözüldü.
• main_window adında TopLevel türünde bir pencere oluşturuldu. Tüm arayüz bu pencere içerisinde oluşturuluyor. root penceresi root.withdraw() metodu ile başlangıçta gizleniyor.
• Resmin arayüze çizilmesi sırasında resim dosyası yüklenirken bir hatayla karşılaşılması durumunda penceredeki tüm resimler siliniyor. Dolayısıyla hatayla karşılaşılması durumunda ekran varsayılan renk olan beyaz renge dönüşüyor.
• Terminale yazdırılan ifadeler basitleştirildi ve gereksiz ifadeler kaldırıldı.
• Fonksiyonların ve değişkenlerin yerleri daha okunabilir olması adına değiştirildi.
• label_thread_main fonksiyonu global değişkenleri kullanmak yerine thread oluşturulurken gönderilen argümanlar sayesinde değişkenlerin referansını kullanarak gerekli argümanlara erişiyor.
• Ana pencere kullanıcı tarafından kapatıldığında root penceresinin kapanmaması sorunu çözüldü.
• Bazen pencereyi kapatırken key_char adlı StringVar nesnesinin main thread üzerinde çalışmadığını belirten hatalar, StringVar nesnesi yerine bir sözlük kullanılıp label_main_thread fonksiyonuna referans olarak gönderilerek düzeltildi.
• Kullanıcı başlangıçta herhangi bir resim veya etiket klasörü seçmez ise programın sonlanması sağlandı.
• Ok tuşlarıyla resimler arasında gezinebilme özelliği eklendi.